### PR TITLE
Discourse embed: Fix invalid property type in embed code.

### DIFF
--- a/Source/Overlays/Article.xyl
+++ b/Source/Overlays/Article.xyl
@@ -28,7 +28,7 @@
     <script type="text/javascript">
       DiscourseEmbed = {
         discourseUrl     : 'https://proxy-discourse.hoa-project.net/',
-        discourseEmbedUrl: window.location
+        discourseEmbedUrl: window.location.toString()
       };
 
       (


### PR DESCRIPTION
The `discourseEmbedUrl` must be a string and window.location is a Location object. In the latest firefox versions, I got the following error :

```
TypeError: DE.discourseEmbedUrl.indexOf is not a function
embed.js:14:9
```