### PR TITLE
Use HTTPS to load Prism.js library within static.hoa-project.net

### DIFF
--- a/Source/Overlays/Article.xyl
+++ b/Source/Overlays/Article.xyl
@@ -23,7 +23,7 @@
   </article>
 
   <yield id="scripts">
-    <script src="http://prismjs.com/prism.js"></script>
+    <script src="https://static.hoa-project.net/Javascript/Prism.js"></script>
 
     <script type="text/javascript">
       DiscourseEmbed = {


### PR DESCRIPTION
Since Prism.js is used on others website pages, we just update the link to point the the `static.hoa-project.net` version.

Related to issue #11.